### PR TITLE
Feat/init std es

### DIFF
--- a/include/iobuf.h
+++ b/include/iobuf.h
@@ -23,6 +23,8 @@ typedef struct _ES_FICHIER {
 extern FICHIER* stdout;
 extern FICHIER* stderr;
 
+void init_es_standard();
+
 /// @brief Opens a file from a given path, uses `open` internally
 /// @param nom The path (relative and absolute supported) of the file to open
 /// @param mode The file opening mode, 'L' for read-only, 'R' for write-only,

--- a/src/iobuf.c
+++ b/src/iobuf.c
@@ -9,6 +9,33 @@
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
+void init_es_standard()
+{
+  stdout = malloc(sizeof(FICHIER));
+  if (stdout == NULL) {
+    exit(10);
+  }
+  stdout->fd = 1;
+  stdout->rbuf = NULL;
+  stdout->wbuf = malloc(MAX_SIZE);
+  if (stdout->wbuf == NULL) {
+    exit(11);
+  }
+  stdout->wbuf_p = 0;
+
+  stderr = malloc(sizeof(FICHIER));
+  if (stderr == NULL) {
+    exit(12);
+  }
+  stderr->fd = 2;
+  stderr->rbuf = NULL;
+  stderr->wbuf = malloc(MAX_SIZE);
+  if (stderr->wbuf == NULL) {
+    exit(13);
+  }
+  stderr->wbuf_p = 0;
+}
+
 FICHIER* ouvrir(const char* nom, char mode)
 {
   int file_fd;

--- a/test/test-format.c
+++ b/test/test-format.c
@@ -12,6 +12,10 @@ char MEMORY[MEMORY_SIZE];
 
 void init_mem(void)
 {
+  init_es_standard();
+  ecriref("Initializing memory...\n");
+  vider(stdout);
+
   int i;
   struct timeval tv;
   gettimeofday(&tv, NULL);

--- a/test/test-rand.c
+++ b/test/test-rand.c
@@ -12,6 +12,10 @@ char MEMORY[MEMORY_SIZE];
 
 void init_mem(void)
 {
+  init_es_standard();
+  ecriref("Initializing memory...\n");
+  vider(stdout);
+
   int i;
   struct timeval tv;
   gettimeofday(&tv, NULL);


### PR DESCRIPTION
Added `init_es_standard` function to open **stdout** and **stderr** and get actual output messages from the program instead of just segfaults